### PR TITLE
[FIX] odoo_install: fix daemon path for RTL support

### DIFF
--- a/odoo_install.sh
+++ b/odoo_install.sh
@@ -180,7 +180,7 @@ cat <<EOF > ~/$OE_CONFIG
 # Short-Description: Enterprise Business Applications
 # Description: ODOO Business Applications
 ### END INIT INFO
-PATH=/bin:/sbin:/usr/bin
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 DAEMON=$OE_HOME_EXT/odoo-bin
 NAME=$OE_CONFIG
 DESC=$OE_CONFIG


### PR DESCRIPTION
Fixes https://github.com/Yenthe666/InstallScript/issues/190
Fixes https://github.com/Yenthe666/InstallScript/issues/183
Before this commit the Daemon was unable to find the correct path to include parts of nodejs. These are needed for RTL support.
After this commit Odoo can find the way to the nodejs files and load RTL